### PR TITLE
ConcurrentModificationException fix

### DIFF
--- a/app/src/main/java/fr/frazew/virtualgyroscope/XposedMod.java
+++ b/app/src/main/java/fr/frazew/virtualgyroscope/XposedMod.java
@@ -248,7 +248,7 @@ public class XposedMod implements IXposedHookLoadPackage {
 
         XposedHelpers.findAndHookMethod("android.hardware.SystemSensorManager", lpparam.classLoader, "unregisterListenerImpl", android.hardware.SensorEventListener.class, android.hardware.Sensor.class, new XC_MethodHook() {
             @Override
-            protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+            protected void afterHookedMethod(MethodHookParam param) throws Throwable {
                 for (Map.Entry<Object, Object> entry : ((HashMap<Object, Object>) XposedHelpers.getObjectField(param.thisObject, "mSensorListeners")).entrySet()) {
                     SensorEventListener listener = (SensorEventListener) entry.getKey();
                     if (listener instanceof GyroscopeEventListener) {


### PR DESCRIPTION
Unregistering listener before previous one was unregistered was causing ConcurrentModificationException.
